### PR TITLE
feat: :sparkles: wraps app in Location context provider

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,19 +3,22 @@ import Hero from './components/hero';
 import Sidebar from './components/sidebar';
 import Content from './components/content';
 import Navbar from './components/navbar';
+import { LocationContextProvider } from './contexts/locationContext';
 
 function App() {
   return (
-    <div
-      className='grid grid-areas-smlayout grid-cols-smlayout grid-rows-smlayout 
+    <LocationContextProvider>
+      <div
+        className='grid grid-areas-smlayout grid-cols-smlayout grid-rows-smlayout 
     md:grid-areas-mdlayout md:grid-cols-mdlayout md:grid-rows-mdlayout 
     h-full bg-gradient-to-br from-slate-300 to-slate-200 bg-auto'
-    >
-      <Hero />
-      <Navbar />
-      <Sidebar />
-      <Content />
-    </div>
+      >
+        <Hero />
+        <Navbar />
+        <Sidebar />
+        <Content />
+      </div>
+    </LocationContextProvider>
   );
 }
 

--- a/src/components/filter.js
+++ b/src/components/filter.js
@@ -1,6 +1,9 @@
+import React, { useContext } from 'react';
 import Location from './location';
+import { LocationContext } from '../contexts/locationContext';
 
 const Filter = () => {
+  const [location] = useContext(LocationContext);
   return (
     <div>
       <h2 className='font-bold text-2xl'>Filters</h2>
@@ -8,18 +11,11 @@ const Filter = () => {
         <summary className='font-bold text-lg'>Locations</summary>
         <div className='form-control rounded-lg p-2 m-1 bg-slate-100'>
           <ul>
-            <li>
-              <Location name='Glasgow' />
-            </li>
-            <li>
-              <Location name='Edinburgh' />
-            </li>
-            <li>
-              <Location name='Leeds' />
-            </li>
-            <li>
-              <Location name='Manchester' />
-            </li>
+            {location.map((location, i) => (
+              <li key={location + i}>
+                <Location name={location.toString()} />
+              </li>
+            ))}
           </ul>
         </div>
       </details>

--- a/src/contexts/locationContext.js
+++ b/src/contexts/locationContext.js
@@ -1,0 +1,12 @@
+import React, { useState, createContext } from 'react';
+
+export const LocationContext = createContext();
+
+export const LocationContextProvider = ({ children }) => {
+  const locations = ['Glasgow', 'Edinburgh', 'London', 'Manchester'];
+  return (
+    <LocationContext.Provider value={useState(locations)}>
+      {children}
+    </LocationContext.Provider>
+  );
+};


### PR DESCRIPTION
The motivation for this change is to start using useContext and a locations context provider to allow the location state to be passed around the app instead of prop drilling.